### PR TITLE
Add nested proxy config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,34 @@ Example config:
   "id": "00000000-0000-0000-0000-000000000000",
   "access_token": "00000000-0000-0000-0000-000000000000",
   "ipv4": "172.16.0.2",
-  "ipv6": "2606:redacted:1"
+  "ipv6": "2606:redacted:1",
+  "socks": {
+    "bind_address": "0.0.0.0",
+    "port": "1080",
+    "username": "",
+    "password": ""
+  },
+  "http": {
+    "bind_address": "0.0.0.0",
+    "port": "8000",
+    "username": "",
+    "password": ""
+  },
+  "tunnel": {
+    "connect_port": 443,
+    "dns": ["9.9.9.9"],
+    "dns_timeout": "2s",
+    "use_ipv6": false,
+    "no_tunnel_ipv4": false,
+    "no_tunnel_ipv6": false,
+    "sni_address": "zt-masque.cloudflareclient.com",
+    "keepalive_period": "30s",
+    "mtu": 1280,
+    "initial_packet_size": 1242,
+    "reconnect_delay": "1s",
+    "connection_timeout": "30s",
+    "idle_timeout": "5m"
+  }
 }
 ```
 
@@ -308,6 +335,30 @@ Example config:
 - `access_token`: Access token given by the server to us upon registration/login. **Confidential.** This is used for API calls.
 - `ipv4`: Internal IPv4 address assigned to the device by the Cloudflare WARP network. **Public.** This is assigned to the device's interface and is also used for communication between devices in the [port forwarding mode](#port-forwarding-mode-for-advanced-users-cross-platform).
 - `ipv6`: Internal IPv6 address assigned to the device by the Cloudflare WARP network. **Public.** This is assigned to the device's interface and is also used for communication between devices in the [port forwarding mode](#port-forwarding-mode-for-advanced-users-cross-platform).
+- `socks`: Object describing the SOCKS proxy configuration.
+  - `bind_address`: Address to bind the SOCKS proxy to. **Public.** Optional.
+  - `port`: Port to listen on for the SOCKS proxy. **Public.** Optional.
+  - `username`: Username for SOCKS proxy authentication. **Confidential.** Optional.
+  - `password`: Password for SOCKS proxy authentication. **Confidential.** Optional.
+- `http`: Object describing the HTTP proxy configuration.
+  - `bind_address`: Address to bind the HTTP proxy to. **Public.** Optional.
+  - `port`: Port to listen on for the HTTP proxy. **Public.** Optional.
+  - `username`: Username for HTTP proxy authentication. **Confidential.** Optional.
+  - `password`: Password for HTTP proxy authentication. **Confidential.** Optional.
+- `tunnel`: MASQUE tunnel configuration.
+  - `connect_port`: Port used for the MASQUE connection.
+  - `dns`: List of DNS servers to use.
+  - `dns_timeout`: Timeout for DNS queries.
+  - `use_ipv6`: Use IPv6 for the MASQUE connection.
+  - `no_tunnel_ipv4`: Disable IPv4 inside the tunnel.
+  - `no_tunnel_ipv6`: Disable IPv6 inside the tunnel.
+  - `sni_address`: SNI address for MASQUE connection.
+  - `keepalive_period`: Keepalive period for the MASQUE connection.
+  - `mtu`: MTU for the MASQUE connection.
+  - `initial_packet_size`: Initial packet size for the MASQUE connection.
+  - `reconnect_delay`: Delay between reconnect attempts.
+  - `connection_timeout`: Timeout for establishing the MASQUE connection.
+  - `idle_timeout`: Idle timeout for the MASQUE connection.
 
 ## ZeroTrust support
 

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -125,6 +125,9 @@ var enrollCmd = &cobra.Command{
 			AccessToken:    accountData.Token,
 			IPv4:           updatedAccountData.Config.Interface.Addresses.V4,
 			IPv6:           updatedAccountData.Config.Interface.Addresses.V6,
+			Socks:          config.ProxyServerConfig{},
+			HTTP:           config.ProxyServerConfig{},
+			Tunnel:         config.TunnelConfig{},
 		}
 
 		config.AppConfig.SaveConfig(configPath)

--- a/cmd/httpproxy.go
+++ b/cmd/httpproxy.go
@@ -72,11 +72,24 @@ var httpProxyCmd = &cobra.Command{
 			cmd.Printf("Failed to get bind address: %v\n", err)
 			return
 		}
+		if config.ConfigLoaded && !cmd.Flags().Changed("bind") && config.AppConfig.HTTP.BindAddress != "" {
+			bindAddress = config.AppConfig.HTTP.BindAddress
+		}
 
 		port, err := cmd.Flags().GetString("port")
 		if err != nil {
 			cmd.Printf("Failed to get port: %v\n", err)
 			return
+		}
+		if config.ConfigLoaded && !cmd.Flags().Changed("port") && config.AppConfig.HTTP.Port != "" {
+			port = config.AppConfig.HTTP.Port
+		}
+
+		if config.ConfigLoaded && !cmd.Flags().Changed("username") && config.AppConfig.HTTP.Username != "" {
+			cmd.Flags().Set("username", config.AppConfig.HTTP.Username)
+		}
+		if config.ConfigLoaded && !cmd.Flags().Changed("password") && config.AppConfig.HTTP.Password != "" {
+			cmd.Flags().Set("password", config.AppConfig.HTTP.Password)
 		}
 
 		connectPort, err := cmd.Flags().GetInt("connect-port")

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -103,6 +103,9 @@ var registerCmd = &cobra.Command{
 			AccessToken:    accountData.Token,
 			IPv4:           updatedAccountData.Config.Interface.Addresses.V4,
 			IPv6:           updatedAccountData.Config.Interface.Addresses.V6,
+			Socks:          config.ProxyServerConfig{},
+			HTTP:           config.ProxyServerConfig{},
+			Tunnel:         config.TunnelConfig{},
 		}
 
 		config.AppConfig.SaveConfig(configPath)

--- a/cmd/socks.go
+++ b/cmd/socks.go
@@ -71,11 +71,24 @@ var socksCmd = &cobra.Command{
 			cmd.Printf("Failed to get bind address: %v\n", err)
 			return
 		}
+		if config.ConfigLoaded && !cmd.Flags().Changed("bind") && config.AppConfig.Socks.BindAddress != "" {
+			bindAddress = config.AppConfig.Socks.BindAddress
+		}
 
 		port, err := cmd.Flags().GetString("port")
 		if err != nil {
 			cmd.Printf("Failed to get port: %v\n", err)
 			return
+		}
+		if config.ConfigLoaded && !cmd.Flags().Changed("port") && config.AppConfig.Socks.Port != "" {
+			port = config.AppConfig.Socks.Port
+		}
+
+		if config.ConfigLoaded && !cmd.Flags().Changed("username") && config.AppConfig.Socks.Username != "" {
+			cmd.Flags().Set("username", config.AppConfig.Socks.Username)
+		}
+		if config.ConfigLoaded && !cmd.Flags().Changed("password") && config.AppConfig.Socks.Password != "" {
+			cmd.Flags().Set("password", config.AppConfig.Socks.Password)
 		}
 
 		connectPort, err := cmd.Flags().GetInt("connect-port")

--- a/config/config.go
+++ b/config/config.go
@@ -8,19 +8,46 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"time"
 )
 
 // Config represents the application configuration structure, containing essential details such as keys, endpoints, and access tokens.
+type ProxyServerConfig struct {
+	BindAddress string `json:"bind_address"` // Address to bind the proxy
+	Port        string `json:"port"`         // Port for the proxy
+	Username    string `json:"username"`     // Username for authentication
+	Password    string `json:"password"`     // Password for authentication
+}
+
+type TunnelConfig struct {
+	ConnectPort       int           `json:"connect_port"`        // MASQUE connection port
+	DNS               []string      `json:"dns"`                 // DNS servers for the tunnel
+	DNSTimeout        time.Duration `json:"dns_timeout"`         // Timeout for DNS queries
+	UseIPv6           bool          `json:"use_ipv6"`            // Use IPv6 for MASQUE connection
+	NoTunnelIPv4      bool          `json:"no_tunnel_ipv4"`      // Disable IPv4 inside the tunnel
+	NoTunnelIPv6      bool          `json:"no_tunnel_ipv6"`      // Disable IPv6 inside the tunnel
+	SNIAddress        string        `json:"sni_address"`         // SNI address for MASQUE connection
+	KeepalivePeriod   time.Duration `json:"keepalive_period"`    // Keepalive period for MASQUE connection
+	MTU               int           `json:"mtu"`                 // MTU for MASQUE connection
+	InitialPacketSize uint16        `json:"initial_packet_size"` // Initial packet size for MASQUE connection
+	ReconnectDelay    time.Duration `json:"reconnect_delay"`     // Delay between reconnect attempts
+	ConnectionTimeout time.Duration `json:"connection_timeout"`  // Timeout for establishing the connection
+	IdleTimeout       time.Duration `json:"idle_timeout"`        // Idle timeout for MASQUE connection
+}
+
 type Config struct {
-	PrivateKey     string `json:"private_key"`      // Base64-encoded ECDSA private key
-	EndpointV4     string `json:"endpoint_v4"`      // IPv4 address of the endpoint
-	EndpointV6     string `json:"endpoint_v6"`      // IPv6 address of the endpoint
-	EndpointPubKey string `json:"endpoint_pub_key"` // PEM-encoded ECDSA public key of the endpoint to verify against
-	License        string `json:"license"`          // Application license key
-	ID             string `json:"id"`               // Device unique identifier
-	AccessToken    string `json:"access_token"`     // Authentication token for API access
-	IPv4           string `json:"ipv4"`             // Assigned IPv4 address
-	IPv6           string `json:"ipv6"`             // Assigned IPv6 address
+	PrivateKey     string            `json:"private_key"`      // Base64-encoded ECDSA private key
+	EndpointV4     string            `json:"endpoint_v4"`      // IPv4 address of the endpoint
+	EndpointV6     string            `json:"endpoint_v6"`      // IPv6 address of the endpoint
+	EndpointPubKey string            `json:"endpoint_pub_key"` // PEM-encoded ECDSA public key of the endpoint to verify against
+	License        string            `json:"license"`          // Application license key
+	ID             string            `json:"id"`               // Device unique identifier
+	AccessToken    string            `json:"access_token"`     // Authentication token for API access
+	IPv4           string            `json:"ipv4"`             // Assigned IPv4 address
+	IPv6           string            `json:"ipv6"`             // Assigned IPv6 address
+	Socks          ProxyServerConfig `json:"socks"`            // SOCKS proxy configuration
+	HTTP           ProxyServerConfig `json:"http"`             // HTTP proxy configuration
+	Tunnel         TunnelConfig      `json:"tunnel"`           // MASQUE tunnel configuration
 }
 
 // AppConfig holds the global application configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	expected := Config{
+		PrivateKey:     "cHJpdmF0ZWtleQ==",
+		EndpointV4:     "127.0.0.1",
+		EndpointV6:     "::1",
+		EndpointPubKey: "-----BEGIN PUBLIC KEY-----\nMFkwE...\n-----END PUBLIC KEY-----\n",
+		License:        "license",
+		ID:             "device-id",
+		AccessToken:    "token",
+		IPv4:           "172.16.0.2",
+		IPv6:           "2606::1",
+		Socks: ProxyServerConfig{
+			BindAddress: "0.0.0.0",
+			Port:        "1080",
+			Username:    "user",
+			Password:    "pass",
+		},
+		HTTP: ProxyServerConfig{
+			BindAddress: "0.0.0.0",
+			Port:        "8000",
+			Username:    "huser",
+			Password:    "hpass",
+		},
+		Tunnel: TunnelConfig{
+			ConnectPort:       443,
+			DNS:               []string{"1.1.1.1"},
+			DNSTimeout:        2 * time.Second,
+			UseIPv6:           true,
+			NoTunnelIPv4:      false,
+			NoTunnelIPv6:      true,
+			SNIAddress:        "example.com",
+			KeepalivePeriod:   30 * time.Second,
+			MTU:               1280,
+			InitialPacketSize: 1242,
+			ReconnectDelay:    time.Second,
+			ConnectionTimeout: 20 * time.Second,
+			IdleTimeout:       5 * time.Minute,
+		},
+	}
+
+	AppConfig = expected
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := AppConfig.SaveConfig(path); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	// Clear and reload
+	AppConfig = Config{}
+	ConfigLoaded = false
+	if err := LoadConfig(path); err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if !ConfigLoaded {
+		t.Fatalf("ConfigLoaded not set")
+	}
+
+	if !reflect.DeepEqual(AppConfig, expected) {
+		t.Fatalf("Loaded config does not match expected")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce `ProxyServerConfig` and `TunnelConfig` types
- allow configuration of socks/http servers under `socks` and `http` keys
- expose MASQUE tunnel options under `tunnel`
- document new JSON structure
- add Go test to verify saving and loading configuration

## Testing
- `go test ./...` *(fails: Forbidden storage.googleapis.com)*
- `go vet ./...` *(fails: Forbidden storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_684cd9149258832aad169d2731e93e55